### PR TITLE
Update elicitation response to match spec

### DIFF
--- a/client/elicitation_test.go
+++ b/client/elicitation_test.go
@@ -38,9 +38,9 @@ func TestClient_HandleElicitationRequest(t *testing.T) {
 			name: "successful elicitation - accept",
 			handler: &mockElicitationHandler{
 				result: &mcp.ElicitationResult{
-					Response: mcp.ElicitationResponse{
-						Type: mcp.ElicitationResponseTypeAccept,
-						Value: map[string]any{
+					ElicitationResponse: mcp.ElicitationResponse{
+						Action: mcp.ElicitationResponseActionAccept,
+						Content: map[string]any{
 							"name":      "test-project",
 							"framework": "react",
 						},
@@ -52,8 +52,8 @@ func TestClient_HandleElicitationRequest(t *testing.T) {
 			name: "successful elicitation - decline",
 			handler: &mockElicitationHandler{
 				result: &mcp.ElicitationResult{
-					Response: mcp.ElicitationResponse{
-						Type: mcp.ElicitationResponseTypeDecline,
+					ElicitationResponse: mcp.ElicitationResponse{
+						Action: mcp.ElicitationResponseActionDecline,
 					},
 				},
 			},
@@ -62,8 +62,8 @@ func TestClient_HandleElicitationRequest(t *testing.T) {
 			name: "successful elicitation - cancel",
 			handler: &mockElicitationHandler{
 				result: &mcp.ElicitationResult{
-					Response: mcp.ElicitationResponse{
-						Type: mcp.ElicitationResponseTypeCancel,
+					ElicitationResponse: mcp.ElicitationResponse{
+						Action: mcp.ElicitationResponseActionCancel,
 					},
 				},
 			},

--- a/client/inprocess_elicitation_test.go
+++ b/client/inprocess_elicitation_test.go
@@ -22,9 +22,9 @@ func (h *MockElicitationHandler) Elicit(ctx context.Context, request mcp.Elicita
 
 	// Simulate user accepting and providing data
 	return &mcp.ElicitationResult{
-		Response: mcp.ElicitationResponse{
-			Type: mcp.ElicitationResponseTypeAccept,
-			Value: map[string]any{
+		ElicitationResponse: mcp.ElicitationResponse{
+			Action: mcp.ElicitationResponseActionAccept,
+			Content: map[string]any{
 				"confirm": true,
 				"details": "User provided additional details",
 			},
@@ -84,12 +84,12 @@ func TestInProcessElicitation(t *testing.T) {
 
 		// Handle the response
 		var responseText string
-		switch result.Response.Type {
-		case mcp.ElicitationResponseTypeAccept:
+		switch result.Action {
+		case mcp.ElicitationResponseActionAccept:
 			responseText = "User accepted and provided data"
-		case mcp.ElicitationResponseTypeDecline:
+		case mcp.ElicitationResponseActionDecline:
 			responseText = "User declined to provide information"
-		case mcp.ElicitationResponseTypeCancel:
+		case mcp.ElicitationResponseActionCancel:
 			responseText = "User cancelled the request"
 		}
 

--- a/examples/elicitation/main.go
+++ b/examples/elicitation/main.go
@@ -50,12 +50,12 @@ func demoElicitationHandler(s *server.MCPServer) server.ToolHandlerFunc {
 		}
 
 		// Handle the user's response
-		switch result.Response.Type {
-		case mcp.ElicitationResponseTypeAccept:
+		switch result.Action {
+		case mcp.ElicitationResponseActionAccept:
 			// User provided the information
-			data, ok := result.Response.Value.(map[string]any)
+			data, ok := result.Content.(map[string]any)
 			if !ok {
-				return nil, fmt.Errorf("unexpected response format: expected map[string]any, got %T", result.Response.Value)
+				return nil, fmt.Errorf("unexpected response format: expected map[string]any, got %T", result.Content)
 			}
 
 			// Safely extract projectName (required field)
@@ -103,18 +103,18 @@ func demoElicitationHandler(s *server.MCPServer) server.ToolHandlerFunc {
 				},
 			}, nil
 
-		case mcp.ElicitationResponseTypeDecline:
+		case mcp.ElicitationResponseActionDecline:
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{
 					mcp.NewTextContent("Project creation cancelled - user declined to provide information"),
 				},
 			}, nil
 
-		case mcp.ElicitationResponseTypeCancel:
+		case mcp.ElicitationResponseActionCancel:
 			return nil, fmt.Errorf("project creation cancelled by user")
 
 		default:
-			return nil, fmt.Errorf("unexpected response type: %s", result.Response.Type)
+			return nil, fmt.Errorf("unexpected response action: %s", result.Action)
 		}
 	}
 }
@@ -183,7 +183,7 @@ func main() {
 					return nil, fmt.Errorf("failed to get confirmation: %w", err)
 				}
 
-				if result.Response.Type != mcp.ElicitationResponseTypeAccept {
+				if result.Action != mcp.ElicitationResponseActionAccept {
 					return &mcp.CallToolResult{
 						Content: []mcp.Content{
 							mcp.NewTextContent("Processing cancelled by user"),
@@ -192,9 +192,9 @@ func main() {
 				}
 
 				// Safely extract response data
-				responseData, ok := result.Response.Value.(map[string]any)
+				responseData, ok := result.Content.(map[string]any)
 				if !ok {
-					return nil, fmt.Errorf("unexpected response format: expected map[string]any, got %T", result.Response.Value)
+					return nil, fmt.Errorf("unexpected response format: expected map[string]any, got %T", result.Content)
 				}
 
 				// Safely extract proceed field

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -842,32 +842,28 @@ type ElicitationParams struct {
 // ElicitationResult represents the result of an elicitation request.
 type ElicitationResult struct {
 	Result
-	// The user's response, which could be:
-	// - The requested information (if user accepted)
-	// - A decline indicator (if user declined)
-	// - A cancel indicator (if user cancelled)
-	Response ElicitationResponse `json:"response"`
+	ElicitationResponse
 }
 
 // ElicitationResponse represents the user's response to an elicitation request.
 type ElicitationResponse struct {
-	// Type indicates whether the user accepted, declined, or cancelled.
-	Type ElicitationResponseType `json:"type"`
-	// Value contains the user's response data if they accepted.
+	// Action indicates whether the user accepted, declined, or cancelled.
+	Action ElicitationResponseAction `json:"action"`
+	// Content contains the user's response data if they accepted.
 	// Should conform to the requestedSchema from the ElicitationRequest.
-	Value any `json:"value,omitempty"`
+	Content any `json:"content,omitempty"`
 }
 
-// ElicitationResponseType indicates how the user responded to an elicitation request.
-type ElicitationResponseType string
+// ElicitationResponseAction indicates how the user responded to an elicitation request.
+type ElicitationResponseAction string
 
 const (
-	// ElicitationResponseTypeAccept indicates the user provided the requested information.
-	ElicitationResponseTypeAccept ElicitationResponseType = "accept"
-	// ElicitationResponseTypeDecline indicates the user explicitly declined to provide information.
-	ElicitationResponseTypeDecline ElicitationResponseType = "decline"
-	// ElicitationResponseTypeCancel indicates the user cancelled without making a choice.
-	ElicitationResponseTypeCancel ElicitationResponseType = "cancel"
+	// ElicitationResponseActionAccept indicates the user provided the requested information.
+	ElicitationResponseActionAccept ElicitationResponseAction = "accept"
+	// ElicitationResponseActionDecline indicates the user explicitly declined to provide information.
+	ElicitationResponseActionDecline ElicitationResponseAction = "decline"
+	// ElicitationResponseActionCancel indicates the user cancelled without making a choice.
+	ElicitationResponseActionCancel ElicitationResponseAction = "cancel"
 )
 
 /* Sampling */

--- a/server/elicitation_test.go
+++ b/server/elicitation_test.go
@@ -117,9 +117,9 @@ func TestMCPServer_RequestElicitation_Success(t *testing.T) {
 	mockSession := &mockElicitationSession{
 		sessionID: "test-session",
 		result: &mcp.ElicitationResult{
-			Response: mcp.ElicitationResponse{
-				Type: mcp.ElicitationResponseTypeAccept,
-				Value: map[string]any{
+			ElicitationResponse: mcp.ElicitationResponse{
+				Action: mcp.ElicitationResponseActionAccept,
+				Content: map[string]any{
 					"projectName": "my-project",
 					"framework":   "react",
 				},
@@ -155,11 +155,11 @@ func TestMCPServer_RequestElicitation_Success(t *testing.T) {
 		return
 	}
 
-	if result.Response.Type != mcp.ElicitationResponseTypeAccept {
-		t.Errorf("expected response type %q, got %q", mcp.ElicitationResponseTypeAccept, result.Response.Type)
+	if result.Action != mcp.ElicitationResponseActionAccept {
+		t.Errorf("expected response type %q, got %q", mcp.ElicitationResponseActionAccept, result.Action)
 	}
 
-	value, ok := result.Response.Value.(map[string]any)
+	value, ok := result.Content.(map[string]any)
 	if !ok {
 		t.Error("expected value to be a map")
 		return
@@ -176,16 +176,16 @@ func TestRequestElicitation(t *testing.T) {
 		session       ClientSession
 		request       mcp.ElicitationRequest
 		expectedError error
-		expectedType  mcp.ElicitationResponseType
+		expectedType  mcp.ElicitationResponseAction
 	}{
 		{
 			name: "successful elicitation with accept",
 			session: &mockElicitationSession{
 				sessionID: "test-1",
 				result: &mcp.ElicitationResult{
-					Response: mcp.ElicitationResponse{
-						Type: mcp.ElicitationResponseTypeAccept,
-						Value: map[string]any{
+					ElicitationResponse: mcp.ElicitationResponse{
+						Action: mcp.ElicitationResponseActionAccept,
+						Content: map[string]any{
 							"name":      "test-project",
 							"framework": "react",
 						},
@@ -204,15 +204,15 @@ func TestRequestElicitation(t *testing.T) {
 					},
 				},
 			},
-			expectedType: mcp.ElicitationResponseTypeAccept,
+			expectedType: mcp.ElicitationResponseActionAccept,
 		},
 		{
 			name: "elicitation declined by user",
 			session: &mockElicitationSession{
 				sessionID: "test-2",
 				result: &mcp.ElicitationResult{
-					Response: mcp.ElicitationResponse{
-						Type: mcp.ElicitationResponseTypeDecline,
+					ElicitationResponse: mcp.ElicitationResponse{
+						Action: mcp.ElicitationResponseActionDecline,
 					},
 				},
 			},
@@ -222,7 +222,7 @@ func TestRequestElicitation(t *testing.T) {
 					RequestedSchema: map[string]any{"type": "object"},
 				},
 			},
-			expectedType: mcp.ElicitationResponseTypeDecline,
+			expectedType: mcp.ElicitationResponseActionDecline,
 		},
 		{
 			name:    "session does not support elicitation",
@@ -252,10 +252,10 @@ func TestRequestElicitation(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
-			assert.Equal(t, tt.expectedType, result.Response.Type)
+			assert.Equal(t, tt.expectedType, result.Action)
 
-			if tt.expectedType == mcp.ElicitationResponseTypeAccept {
-				assert.NotNil(t, result.Response.Value)
+			if tt.expectedType == mcp.ElicitationResponseActionAccept {
+				assert.NotNil(t, result.Action)
 			}
 		})
 	}


### PR DESCRIPTION
The current implementation didn't work when testing with vscode. We were always receiving empty response back. After some digging, it looks like the response struct needed to be updated to match the specs. We tested and verified PR in vscode and vscode clones.